### PR TITLE
Enable EPEL & fix rpmlint installation

### DIFF
--- a/Sanity/rpmlint/main.fmf
+++ b/Sanity/rpmlint/main.fmf
@@ -3,8 +3,7 @@ contact: Dalibor Pospisil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:
 - library(ControlFlow/Cleanup)
-recommend:
-- rpmlint
+- epel-release
 duration: 5m
 enabled: true
 tag:

--- a/Sanity/rpmlint/runtest.sh
+++ b/Sanity/rpmlint/runtest.sh
@@ -32,7 +32,8 @@ PACKAGE="librdkafka"
 
 rlJournalStart && {
     rlPhaseStartSetup
-        rlRun "rlCheckMakefileRequires" || rlDie "cannot continue"
+        rlRun "dnf config-manager --set-enable epel" 0 "Enable EPEL"
+        rlRun "dnf install -y rpmlint" 0 "Install rpmlint"
         rlRun "rlImport --all" 0 "Import libraries" || rlDie "cannot continue"
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         CleanupRegister "rlRun 'rm -r $TmpDir' 0 'Removing tmp directory'"


### PR DESCRIPTION
rpmlint package was moved to epel repository. Based on that, we need to enable epel repository and install the package from it.